### PR TITLE
don't limit LV2 to non-Apple Unix

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-12]
 
     steps:
     - name: Linux Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-12]
+        os: [ubuntu-latest, windows-2022, macos-12]
 
     steps:
     - name: Linux Build
@@ -37,7 +37,7 @@ jobs:
           libx11-dev libxcomposite-dev libxcursor-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev \
           libwebkit2gtk-4.0-dev \
           libglu1-mesa-dev mesa-common-dev
-          
+
     - uses: actions/checkout@v3
       with:
         submodules: recursive

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-13]
 
     steps:
     - name: Linux Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,11 @@ jobs:
         matrix:
           include:
             - name: Linux
-              os: ubuntu-20.04
+              os: ubuntu-22.04
             - name: macOS
-              os: macos-12
+              os: macos-13
             - name: Windows
-              os: windows-2019
+              os: windows-2022
 
     steps:
 
@@ -112,7 +112,7 @@ jobs:
         echo "ARTIFACT=${{ env.PROJECT }}-linux.tar.xz" >> "$GITHUB_ENV"
         mkdir bin
         cp ${{ env.PROJECT }}-linux.tar.xz bin/
-      
+
     - name: Build (Windows)
       if: runner.os == 'Windows'
       shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,7 +133,7 @@ jobs:
         timestamp-server: 'http://timestamp.digicert.com'
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT }}
         path: bin/${{ env.ARTIFACT }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,17 +20,13 @@ add_subdirectory(modules/juce)
 
 add_subdirectory(modules/clap-juce-extensions EXCLUDE_FROM_ALL)
 
-set(JUCE_FORMATS AU VST3)
+set(JUCE_FORMATS AU VST3 LV2)
 
 if (BUILD_VST2)
 	juce_set_vst2_sdk_path(./vst2_sdk)
 	list(APPEND JUCE_FORMATS VST)
 else()
 	set(BUILD_VST2 OFF)
-endif()
-
-if (UNIX AND NOT APPLE)
-	list(APPEND JUCE_FORMATS LV2)
 endif()
 
 if (NOT INSTALL)


### PR DESCRIPTION
LV2 is a cross-platform format that also works on both macOS and Windows.

It's therefore safe to enable in the default set of JUCE_FORMATS.